### PR TITLE
Feature/unittest to pytest

### DIFF
--- a/great_expectations/dataset/base.py
+++ b/great_expectations/dataset/base.py
@@ -75,7 +75,7 @@ class DataSet(object):
             try:
                 return_obj = func(self, output_format=output_format, **all_args)
 
-            except Exception, err:
+            except Exception as err:
                 if catch_exceptions:
                     raised_exception = True
                     exception_traceback = traceback.format_exc()
@@ -179,7 +179,7 @@ class DataSet(object):
                 ## Changed to support python 3, but note that there may be ambiguity here.
                 ## TODO: ensure this is the intended logic
                 "kwargs" : dict(
-                    zip(method_arg_names, args)+kwargs.items()
+                    list(zip(method_arg_names, args))+list(kwargs.items())
                 )
             })
 
@@ -316,7 +316,7 @@ class DataSet(object):
             result = expectation_method(**expectation['kwargs'])
 
             results.append(
-                dict(expectation.items() + result.items())
+                dict(list(expectation.items()) + list(result.items()))
             )
 
         return {

--- a/great_expectations/dataset/pandas_dataset.py
+++ b/great_expectations/dataset/pandas_dataset.py
@@ -489,9 +489,24 @@ class PandasDataSet(MetaPandasDataSet, pd.DataFrame):
 
     @MetaPandasDataSet.column_map_expectation
     def expect_column_values_to_be_between(self, series, min_value=None, max_value=None):
-        return series.map(
-            lambda x: ((min_value <= x) | (min_value == None)) and ((x <= max_value) | (max_value ==None))
-        )
+
+        if min_value != None and max_value != None:
+            return series.map(
+                lambda x: (min_value <= x) and (x <= max_value)
+            )
+
+        elif min_value == None and max_value != None:
+            return series.map(
+                lambda x: (x <= max_value)
+            )
+
+        elif min_value != None and max_value == None:
+            return series.map(
+                lambda x: (min_value <= x)
+            )
+
+        else:
+            raise ValueError("min_value and max_value cannot both be None")
 
     # @DataSet.old_column_expectation
     # def expect_column_values_to_be_between(self, column, min_value, max_value, mostly=None, suppress_exceptions=False):
@@ -895,10 +910,20 @@ class PandasDataSet(MetaPandasDataSet, pd.DataFrame):
     def expect_column_unique_value_count_to_be_between(self, series, min_value=None, max_value=None, output_format=None):
         unique_value_count = series.value_counts().shape[0]
 
-        return (
-            ((min_value <= unique_value_count) | (min_value == None)) and
-            ((unique_value_count <= max_value) | (max_value ==None))
-        ), unique_value_count
+        if min_value != None and max_value != None:
+            return (
+                (min_value <= unique_value_count) and
+                (unique_value_count <= max_value)
+            ), unique_value_count
+            
+        elif min_value == None and max_value != None:
+            return (x <= max_value), unique_value_count
+
+        elif min_value != None and max_value == None:
+            return (min_value <= x), unique_value_count
+
+        else:
+            raise ValueError("min_value and max_value cannot both be None")
 
     @MetaPandasDataSet.column_aggregate_expectation
     def expect_column_proportion_of_unique_values_to_be_between(self, series, min_value=None, max_value=None, output_format=None):

--- a/great_expectations/dataset/pandas_dataset.py
+++ b/great_expectations/dataset/pandas_dataset.py
@@ -490,23 +490,24 @@ class PandasDataSet(MetaPandasDataSet, pd.DataFrame):
     @MetaPandasDataSet.column_map_expectation
     def expect_column_values_to_be_between(self, series, min_value=None, max_value=None):
 
-        if min_value != None and max_value != None:
-            return series.map(
-                lambda x: (min_value <= x) and (x <= max_value)
-            )
+        def is_between(val):
+            # TODO Might be worth explicitly defining comparisons between types (for example, between strings and ints).
+            if type(val) == str:
+                raise TypeError("cannot compare type 'str'")
 
-        elif min_value == None and max_value != None:
-            return series.map(
-                lambda x: (x <= max_value)
-            )
+            if min_value != None and max_value != None:
+                return (min_value <= val) and (val <= max_value)
 
-        elif min_value != None and max_value == None:
-            return series.map(
-                lambda x: (min_value <= x)
-            )
+            elif min_value == None and max_value != None:
+                return (val <= max_value)
 
-        else:
-            raise ValueError("min_value and max_value cannot both be None")
+            elif min_value != None and max_value == None:
+                return (min_value <= val)
+
+            else:
+                raise ValueError("min_value and max_value cannot both be None")
+
+        return series.map(is_between)
 
     # @DataSet.old_column_expectation
     # def expect_column_values_to_be_between(self, column, min_value, max_value, mostly=None, suppress_exceptions=False):
@@ -917,10 +918,10 @@ class PandasDataSet(MetaPandasDataSet, pd.DataFrame):
             ), unique_value_count
             
         elif min_value == None and max_value != None:
-            return (x <= max_value), unique_value_count
+            return (unique_value_count <= max_value), unique_value_count
 
         elif min_value != None and max_value == None:
-            return (min_value <= x), unique_value_count
+            return (min_value <= unique_value_count), unique_value_count
 
         else:
             raise ValueError("min_value and max_value cannot both be None")

--- a/great_expectations/dataset/pandas_dataset.py
+++ b/great_expectations/dataset/pandas_dataset.py
@@ -492,22 +492,28 @@ class PandasDataSet(MetaPandasDataSet, pd.DataFrame):
 
         def is_between(val):
             # TODO Might be worth explicitly defining comparisons between types (for example, between strings and ints).
-            if type(val) == str:
-                raise TypeError("cannot compare type 'str'")
-
-            if min_value != None and max_value != None:
-                return (min_value <= val) and (val <= max_value)
-
-            elif min_value == None and max_value != None:
-                return (val <= max_value)
-
-            elif min_value != None and max_value == None:
-                return (min_value <= val)
-
+            # Ensure types can be compared since some types in Python 3 cannot be logically compared.
+            if type(val) == None:
+                return False
             else:
-                raise ValueError("min_value and max_value cannot both be None")
+                try:
+
+                    if min_value != None and max_value != None:
+                        return (min_value <= val) and (val <= max_value)
+
+                    elif min_value == None and max_value != None:
+                        return (val <= max_value)
+
+                    elif min_value != None and max_value == None:
+                        return (min_value <= val)
+
+                    else:
+                        raise ValueError("min_value and max_value cannot both be None")
+                except:
+                    return False
 
         return series.map(is_between)
+
 
     # @DataSet.old_column_expectation
     # def expect_column_values_to_be_between(self, column, min_value, max_value, mostly=None, suppress_exceptions=False):

--- a/great_expectations/dataset/util.py
+++ b/great_expectations/dataset/util.py
@@ -19,7 +19,7 @@ def ensure_json_serializable(test_dict):
     # TODO: ensure in-place iteration like this is okay
     for key in test_dict:
         ## TODO: Brittle if non python3 (unicode, long type?)
-        if isinstance(test_dict[key], (list, tuple, str, unicode, int, float, bool)):
+        if isinstance(test_dict[key], (list, tuple, str, int, float, bool)):
             # No problem to encode json
             continue
 

--- a/great_expectations/dataset/util.py
+++ b/great_expectations/dataset/util.py
@@ -34,7 +34,14 @@ def ensure_json_serializable(test_dict):
             test_dict[key] = ensure_json_serializable(test_dict[key])
 
         else:
-            raise TypeError(key + ' is type ' + type(test_dict[key]).__name__ + ' which cannot be serialized.')
+            try:
+                # In Python 2, unicode and long should still be valid.
+                # This will break in Python 3 and throw the exception instead.
+                if isinstance(test_dict[key], (long, unicode)):
+                    # No problem to encode json
+                    continue
+            except:
+                raise TypeError(key + ' is type ' + type(test_dict[key]).__name__ + ' which cannot be serialized.')
 
     return test_dict
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -84,3 +84,6 @@ class TestDataset(unittest.TestCase):
                 "output_format" : 'SUMMARY',
             }
         )
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_expectation_decorators.py
+++ b/tests/test_expectation_decorators.py
@@ -10,7 +10,7 @@
 # from nose.tools import *
 import unittest
 import great_expectations as ge
-reload(ge)
+#reload(ge)
 # from great_expectations.dataset import PandasDataSet
 PandasDataSet = ge.dataset.PandasDataSet
 
@@ -262,7 +262,7 @@ class TestExpectationDecorators(unittest.TestCase):
 
         self.assertEqual(
             set(result_obj.keys()),
-            set(comparison_obj.keys()+['exception_traceback']),
+            set(list(comparison_obj.keys())+['exception_traceback']),
         )
 
         for k,v in comparison_obj.items():
@@ -297,3 +297,5 @@ class TestExpectationDecorators(unittest.TestCase):
         # with self.assertRaises(ZeroDivisionError):
         #     df.expectation_that_crashes_on_sixes("all_even", catch_exceptions=False)
 
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_expectation_decorators.py
+++ b/tests/test_expectation_decorators.py
@@ -275,7 +275,7 @@ class TestExpectationDecorators(unittest.TestCase):
 
         self.assertEqual(
             result_obj["exception_traceback"].split('\n')[-2],
-            "ZeroDivisionError: integer division or modulo by zero",
+            "ZeroDivisionError: division by zero",
         )
 
         self.assertEqual(

--- a/tests/test_expectation_decorators.py
+++ b/tests/test_expectation_decorators.py
@@ -4,10 +4,10 @@
 # import numpy as np
 # import random
 # import os
-# import sys
 # import inspect
 
 # from nose.tools import *
+import sys
 import unittest
 import great_expectations as ge
 #reload(ge)
@@ -273,10 +273,17 @@ class TestExpectationDecorators(unittest.TestCase):
             "",
         )
 
-        self.assertEqual(
-            result_obj["exception_traceback"].split('\n')[-2],
-            "ZeroDivisionError: division by zero",
-        )
+        if sys.version_info[0] == 3:
+            self.assertEqual(
+                result_obj["exception_traceback"].split('\n')[-2],
+                "ZeroDivisionError: division by zero",
+            )
+
+        else:
+            self.assertEqual(
+                result_obj["exception_traceback"].split('\n')[-2],
+                "ZeroDivisionError: integer division or modulo by zero",
+            )
 
         self.assertEqual(
             result_obj["exception_traceback"].split('\n')[-3],

--- a/tests/test_great_expectations.py
+++ b/tests/test_great_expectations.py
@@ -89,17 +89,21 @@ class TestCustomClass(unittest.TestCase):
 
 class TestValidation(unittest.TestCase):
     def test_validate(self):
-        my_expectations_config = json.load(file("./tests/examples/titanic_expectations.json"))
+
+        with open("./tests/examples/titanic_expectations.json") as f:
+            my_expectations_config = json.load(f)
+
         my_df = ge.read_csv(
-            "./tests/examples/titanic.csv",
+            "./tests/examples/Titanic.csv",
             expectations_config=my_expectations_config
         )
 
         results = my_df.validate()
         # print json.dumps(results, indent=2)
 
-        expected_results = json.load(file('./tests/examples/expected_results_20170721.json'))
-        # print json.dumps(expected_results, indent=2)
+        with open('./tests/examples/expected_results_20170721.json') as f:
+            expected_results = json.load(f)
+            # print json.dumps(expected_results, indent=2)
 
         self.maxDiff = None
         #!!! This needs to be converted to unicode, I think
@@ -108,8 +112,11 @@ class TestValidation(unittest.TestCase):
 
 class TestRepeatedAppendExpectation(unittest.TestCase):
     def test_validate(self):
-        my_expectations_config = json.load(file("./tests/examples/titanic_expectations.json"))
-        my_df = ge.read_csv("./tests/examples/titanic.csv")
+
+        with open("./tests/examples/titanic_expectations.json") as f:
+            my_expectations_config = json.load(f)
+
+        my_df = ge.read_csv("./tests/examples/Titanic.csv")
 
         self.assertEqual(
             len(my_df.get_expectations_config()['expectations']),
@@ -124,3 +131,5 @@ class TestRepeatedAppendExpectation(unittest.TestCase):
         )
 
 
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pandas_dataset.py
+++ b/tests/test_pandas_dataset.py
@@ -776,7 +776,7 @@ class TestPandasDataset(unittest.TestCase):
         ]
 
         for t in T:
-            print t
+            print(t)
             out = D2.expect_column_values_to_match_regex(**t['in'])#, **t['kwargs'])
             self.assertEqual(out, t['out'])
 
@@ -1117,8 +1117,14 @@ class TestPandasDataset(unittest.TestCase):
 
         for t in T:
             # print t['in'], t['out']
-            out = D.expect_column_unique_value_count_to_be_between(**t['in'])
-            self.assertEqual(out, t['out'])
+            if t['in']['min_value'] == None and t['in']['max_value'] == None:
+                with self.assertRaises(Exception) as e:
+                    D.expect_column_unique_value_count_to_be_between(**t['in'])
+                self.assertTrue('min_value and max_value cannot both be None', str(e.exception))
+
+            else:
+                out = D.expect_column_unique_value_count_to_be_between(**t['in'])
+                self.assertEqual(out, t['out'])
 
     def test_expect_column_unique_proportion_to_be_between(self):
 

--- a/tests/test_pandas_dataset.py
+++ b/tests/test_pandas_dataset.py
@@ -611,8 +611,9 @@ class TestPandasDataset(unittest.TestCase):
             'z' : [1, 2, 3, 4, 5, None, None, None, None, None],
         })
 
-        T = json.load(file("./tests/test_sets/expect_column_values_to_be_between_test_set_ADJ.json"))
-        # print json.dumps(T, indent=2)
+        with open("./tests/test_sets/expect_column_values_to_be_between_test_set_ADJ.json") as f:
+            T = json.load(f)
+            # print json.dumps(T, indent=2)
 
         for t in T:
             out = D.expect_column_values_to_be_between(**t['in'])#, **t['kwargs'])

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -63,7 +63,7 @@ class TestUtilMethods(unittest.TestCase):
 
     def test_partition_data_norm_0_1(self):
         test_partition = ge.dataset.util.partition_data(self.D.norm_0_1)
-        for key, val in self.auto_partition_norm_0_1.iteritems():
+        for key, val in self.auto_partition_norm_0_1.items():
             self.assertEqual(len(val), len(test_partition[key]))
             for k in range(len(val)):
                 # NOTE ARBITRARY "CLOSE PARAMETER"
@@ -71,7 +71,7 @@ class TestUtilMethods(unittest.TestCase):
 
     def test_partition_data_bimodal(self):
         test_partition = ge.dataset.util.partition_data(self.D.bimodal)
-        for key, val in self.auto_partition_bimodal.iteritems():
+        for key, val in self.auto_partition_bimodal.items():
             self.assertEqual(len(val), len(test_partition[key]))
             for k in range(len(val)):
                 # NOTE ARBITRARY "CLOSE PARAMETER"
@@ -79,7 +79,7 @@ class TestUtilMethods(unittest.TestCase):
 
     def test_kde_smooth_data_norm_0_1(self):
         test_partition = ge.dataset.util.kde_smooth_data(self.D.norm_0_1)
-        for key, val in self.kde_smooth_partition_norm_0_1.iteritems():
+        for key, val in self.kde_smooth_partition_norm_0_1.items():
             self.assertEqual(len(val), len(test_partition[key]))
             for k in range(len(val)):
                 # NOTE ARBITRARY "CLOSE PARAMETER"
@@ -87,7 +87,7 @@ class TestUtilMethods(unittest.TestCase):
 
     def test_kde_smooth_data_bimodal(self):
         test_partition = ge.dataset.util.kde_smooth_data(self.D.bimodal)
-        for key, val in self.kde_smooth_partition_bimodal.iteritems():
+        for key, val in self.kde_smooth_partition_bimodal.items():
             self.assertEqual(len(val), len(test_partition[key]))
             for k in range(len(val)):
                 # NOTE ARBITRARY "CLOSE PARAMETER"
@@ -120,3 +120,6 @@ class TestUtilMethods(unittest.TestCase):
     def test_ensure_json_serializable(self):
         # TODO: Make a meaningful test
         self.assertEqual(1,1)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request modifies the code base to increase compatibility between Python 2 and Python 3. At present, running "python -m unittest" as well as "nosetests" from the root directory gives 4 failures. Two of the failures come from small inaccuracies in the distributional expectations output. The other two failures are due to type mismatch in the output format, likely caused because of type handling differences in Python 2 vs 3.